### PR TITLE
Support commas when parsing periods and durations

### DIFF
--- a/duration_test.go
+++ b/duration_test.go
@@ -3,6 +3,7 @@ package chrono_test
 import (
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/go-chrono/chrono"
@@ -538,14 +539,26 @@ func TestDuration_Parse(t *testing.T) {
 						expected *= -1
 					}
 
-					var d chrono.Duration
-					if err := d.Parse(input); err != nil {
-						t.Errorf("failed to parse duation: %v", err)
-					} else if d.Compare(chrono.DurationOf(expected)) != 0 {
-						t.Errorf("parsed duration = %v, want %v", d, expected)
+					run := func() {
+						var d chrono.Duration
+						if err := d.Parse(input); err != nil {
+							t.Errorf("failed to parse duation: %v", err)
+						} else if d.Compare(chrono.DurationOf(expected)) != 0 {
+							t.Errorf("parsed duration = %v, want %v", d, expected)
+						}
 					}
+
+					t.Run("dots", func(t *testing.T) {
+						run()
+					})
+
+					t.Run("commas", func(t *testing.T) {
+						tt.input = strings.ReplaceAll(tt.input, ".", ",")
+						run()
+					})
 				})
 			}
+
 		})
 	}
 

--- a/period.go
+++ b/period.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 )
 
 // Period represents an amount of time in years, months, weeks and days.
@@ -105,7 +106,7 @@ func parseDuration(s string, parsePeriod, parseTime bool) (years, months, weeks,
 	var haveWeeks int // 0 = undecided, 1 = W, -1 = YMD
 
 	for i := offset; i < len(s); i++ {
-		digit := (s[i] >= '0' && s[i] <= '9') || s[i] == '.'
+		digit := (s[i] >= '0' && s[i] <= '9') || s[i] == '.' || s[i] == ','
 
 		if value == 0 {
 			if digit {
@@ -127,7 +128,7 @@ func parseDuration(s string, parsePeriod, parseTime bool) (years, months, weeks,
 					continue
 				}
 
-				v, err := strconv.ParseFloat(s[value:i], 32)
+				v, err := parseFloat(s[value:i], 32)
 				if err != nil {
 					return 0, 0, 0, 0, 0, 0, false, err
 				}
@@ -168,7 +169,7 @@ func parseDuration(s string, parsePeriod, parseTime bool) (years, months, weeks,
 					continue
 				}
 
-				v, err := strconv.ParseFloat(s[value:i], 64)
+				v, err := parseFloat(s[value:i], 64)
 				if err != nil {
 					return 0, 0, 0, 0, 0, 0, false, err
 				}
@@ -219,4 +220,9 @@ func parseDuration(s string, parsePeriod, parseTime bool) (years, months, weeks,
 		return 0, 0, 0, 0, 0, 0, false, fmt.Errorf("expecting at least one unit")
 	}
 	return
+}
+
+func parseFloat(s string, bitSize int) (float64, error) {
+	s = strings.ReplaceAll(s, ",", ".")
+	return strconv.ParseFloat(s, bitSize)
 }

--- a/period_test.go
+++ b/period_test.go
@@ -1,6 +1,7 @@
 package chrono_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/go-chrono/chrono"
@@ -200,13 +201,24 @@ func TestParseDuration(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			if p, d, err := chrono.ParseDuration(tt.input); err != nil {
-				t.Errorf("failed to parse period & duration: %v", err)
-			} else if !p.Equal(tt.period) {
-				t.Errorf("parsed period = %v, want %v", p, tt.period)
-			} else if d.Compare(tt.duration) != 0 {
-				t.Errorf("parsed duration = %v, want %v", d, tt.duration)
+			run := func() {
+				if p, d, err := chrono.ParseDuration(tt.input); err != nil {
+					t.Errorf("failed to parse period & duration: %v", err)
+				} else if !p.Equal(tt.period) {
+					t.Errorf("parsed period = %v, want %v", p, tt.period)
+				} else if d.Compare(tt.duration) != 0 {
+					t.Errorf("parsed duration = %v, want %v", d, tt.duration)
+				}
 			}
+
+			t.Run("dots", func(t *testing.T) {
+				run()
+			})
+
+			t.Run("commas", func(t *testing.T) {
+				tt.input = strings.ReplaceAll(tt.input, ".", ",")
+				run()
+			})
 		})
 	}
 


### PR DESCRIPTION
As per ISO 8601, when parsing durations, commas as well as dots should be accepted as decimal marks.

Closes https://github.com/go-chrono/chrono/issues/9