### PR TITLE
Implement Duration.Units

### DIFF
--- a/duration.go
+++ b/duration.go
@@ -94,6 +94,16 @@ func (d Duration) String() string {
 	return d.Format()
 }
 
+// Units returns the whole numbers of hours, minutes, seconds, and nanosecond offset represented by d.
+func (d Duration) Units() (hours, mins, secs, nsec int) {
+	_secs, _nsec, _ := d.integers()
+	hours = int(_secs / 3600)
+	mins = int((_secs / 60) % 60)
+	secs = int(_secs % 60)
+	nsec = int(_nsec)
+	return
+}
+
 // Designator of date and time elements present in ISO 8601.
 type Designator rune
 

--- a/duration_test.go
+++ b/duration_test.go
@@ -578,22 +578,22 @@ func TestDuration_Parse(t *testing.T) {
 }
 
 func TestDuration_Units(t *testing.T) {
-	d := chrono.DurationOf(1*chrono.Hour + 2*chrono.Minute + 3*chrono.Second + 4*chrono.Nanosecond)
+	d := chrono.DurationOf(12*chrono.Hour + 34*chrono.Minute + 56*chrono.Second + 7*chrono.Nanosecond)
 
 	hours, mins, secs, nsec := d.Units()
-	if hours != 1 {
-		t.Errorf("expecting 1 hour, got %d", hours)
+	if hours != 12 {
+		t.Errorf("expecting 12 hours, got %d", hours)
 	}
 
-	if mins != 2 {
-		t.Errorf("expecting 2 mins, got %d", mins)
+	if mins != 34 {
+		t.Errorf("expecting 34 mins, got %d", mins)
 	}
 
-	if secs != 3 {
-		t.Errorf("expecting 3 secs, got %d", secs)
+	if secs != 56 {
+		t.Errorf("expecting 56 secs, got %d", secs)
 	}
 
-	if nsec != 4 {
-		t.Errorf("expecting 4 nsecs, got %d", nsec)
+	if nsec != 7 {
+		t.Errorf("expecting 7 nsecs, got %d", nsec)
 	}
 }

--- a/duration_test.go
+++ b/duration_test.go
@@ -576,3 +576,24 @@ func TestDuration_Parse(t *testing.T) {
 		}
 	})
 }
+
+func TestDuration_Units(t *testing.T) {
+	d := chrono.DurationOf(1*chrono.Hour + 2*chrono.Minute + 3*chrono.Second + 4*chrono.Nanosecond)
+
+	hours, mins, secs, nsec := d.Units()
+	if hours != 1 {
+		t.Errorf("expecting 1 hour, got %d", hours)
+	}
+
+	if mins != 2 {
+		t.Errorf("expecting 2 mins, got %d", mins)
+	}
+
+	if secs != 3 {
+		t.Errorf("expecting 3 secs, got %d", secs)
+	}
+
+	if nsec != 4 {
+		t.Errorf("expecting 4 nsecs, got %d", nsec)
+	}
+}

--- a/extent.go
+++ b/extent.go
@@ -54,6 +54,15 @@ func (e Extent) Hours() float64 {
 	return float64(hours) + float64(nsec)/(60*60*1e9)
 }
 
+// Units returns the whole numbers of hours, minutes, seconds, and nanosecond offset represented by e.
+func (e Extent) Units() (hours, mins, secs, nsec int) {
+	hours = int(e / Hour)
+	mins = int(e/Minute) % 60
+	secs = int(e/Second) % 60
+	nsec = int(e % Second)
+	return
+}
+
 // Truncate returns the result of rounding e toward zero to a multiple of m.
 func (e Extent) Truncate(m Extent) Extent {
 	if m <= 0 {

--- a/extent_test.go
+++ b/extent_test.go
@@ -23,3 +23,24 @@ func TestExtent_Truncate(t *testing.T) {
 		}
 	})
 }
+
+func TestExtent_Units(t *testing.T) {
+	e := (12 * chrono.Hour) + (34 * chrono.Minute) + (56 * chrono.Second) + (7 * chrono.Nanosecond)
+
+	hours, mins, secs, nsec := e.Units()
+	if hours != 12 {
+		t.Errorf("expecting 12 hours, got %d", hours)
+	}
+
+	if mins != 34 {
+		t.Errorf("expecting 34 mins, got %d", mins)
+	}
+
+	if secs != 56 {
+		t.Errorf("expecting 56 secs, got %d", secs)
+	}
+
+	if nsec != 7 {
+		t.Errorf("expecting 7 nsecs, got %d", nsec)
+	}
+}


### PR DESCRIPTION
`Duration.Units` returns the whole numbers of hours, minutes and seconds.