### PR TITLE
Support parsing & formatting with `%f`, `%3f`, `%6f`, and `%9f`

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -8,3 +8,5 @@ func SetupCenturyParsing(v int) {
 func TearDownCenturyParsing() {
 	overrideCentury = nil
 }
+
+var DivideAndRoundIntFunc = divideAndRoundInt

--- a/format.go
+++ b/format.go
@@ -36,8 +36,8 @@ import (
 //   %S: The second as a decimal number, padded to 2 digits with a leading 0, in the range 00 to 59.
 //
 //   %f: Equivalent to %6f.
-//  %3f: The millisecond offset within the represented second, padded to 3 digits with a leading 0.
-//  %6f: The microsecond offset within the represented second, padded to 6 digits with a leading 0.
+//  %3f: The millisecond offset within the represented second, rounded either up or down and padded to 3 digits with a leading 0.
+//  %6f: The microsecond offset within the represented second, rounded either up or down and padded to 6 digits with a leading 0.
 //  %9f: The nanosecond offset within the represented second, padded to 9 digits with a leading 0.
 //
 // When formatting using specifiers that represent padded decimals, leading 0s can be omitted using the '-' character after the '%'.

--- a/format.go
+++ b/format.go
@@ -35,6 +35,11 @@ import (
 //   %M: The minute as a decimal number, padded to 2 digits with a leading 0, in the range 00 to 59.
 //   %S: The second as a decimal number, padded to 2 digits with a leading 0, in the range 00 to 59.
 //
+//   %f: Equivalent to %6f.
+//  %3f: The millisecond offset within the represented second, padded to 3 digits with a leading 0.
+//  %6f: The microsecond offset within the represented second, padded to 6 digits with a leading 0.
+//  %9f: The nanosecond offset within the represented second, padded to 9 digits with a leading 0.
+//
 // When formatting using specifiers that represent padded decimals, leading 0s can be omitted using the '-' character after the '%'.
 // For example, '%m' may produce the string '04' (for March), but '%-m' produces '4'.
 // However, when parsing using these specifiers, it is not required that the input string contains any leading zeros.
@@ -110,11 +115,11 @@ NextChar:
 		buf = append(buf, c)
 
 		if len(buf) >= 2 && buf[0] == '%' {
-			if c == '-' || c == 'E' {
+			if c == '-' || c == 'E' || (c >= '0' && c <= '9') {
 				continue NextChar
 			}
 
-			nopad, localed, main, err := parseSpecifier(buf)
+			nopad, localed, precision, main, err := parseSpecifier(buf)
 			if err != nil {
 				return "", err
 			}
@@ -147,6 +152,22 @@ NextChar:
 				}
 			case date != nil && main == 'd': // %d
 				out = append(out, []rune(decimal(day, 2))...)
+			case time != nil && main == 'f': // %f
+				if precision == 0 {
+					precision = 6
+				}
+
+				nanos := time.Nanosecond()
+				switch precision {
+				case 3: // %3f
+					out = append(out, []rune(decimal(divideAndRoundInt(nanos, 1000000), 3))...)
+				case 6: // %6f
+					out = append(out, []rune(decimal(divideAndRoundInt(nanos, 1000), 6))...)
+				case 9: // %9f
+					out = append(out, []rune(decimal(nanos, 9))...)
+				default:
+					panic(fmt.Sprintf("unsupported specifier '%df'", precision))
+				}
 			case date != nil && main == 'G': // %G
 				y, _ := date.ISOWeek()
 				out = append(out, []rune(decimal(y, 4))...)
@@ -347,7 +368,7 @@ func parse(layout, value string, date, time *int64) error {
 				return string(_lower[:i]), string(_original[:i])
 			}
 
-			_, localed, main, err := parseSpecifier(buf)
+			_, localed, _, main, err := parseSpecifier(buf)
 			if err != nil {
 				return err
 			}
@@ -612,32 +633,34 @@ func parse(layout, value string, date, time *int64) error {
 	return nil
 }
 
-func parseSpecifier(buf []rune) (nopad, localed bool, main rune, err error) {
+func parseSpecifier(buf []rune) (nopad, localed bool, precision uint, main rune, err error) {
 	if len(buf) == 3 {
-		switch buf[1] {
-		case '-':
+		switch {
+		case buf[1] == '-':
 			nopad = true
-		case 'E':
+		case buf[1] == 'E':
 			localed = true
+		case buf[1] >= '0' && buf[1] <= '9':
+			precision = uint(buf[1] - 48)
 		default:
-			return false, false, 0, fmt.Errorf("unsupported modifier '%c'", buf[1])
+			return false, false, 0, 0, fmt.Errorf("unsupported modifier '%c'", buf[1])
 		}
 	} else if len(buf) == 4 {
 		switch buf[1] {
 		case '-':
 			nopad = true
 		default:
-			return false, false, 0, fmt.Errorf("unsupported modifier '%c'", buf[1])
+			return false, false, 0, 0, fmt.Errorf("unsupported modifier '%c'", buf[1])
 		}
 
 		switch buf[2] {
 		case 'E':
 			localed = true
 		default:
-			return false, false, 0, fmt.Errorf("unsupported modifier '%c'", buf[1])
+			return false, false, 0, 0, fmt.Errorf("unsupported modifier '%c'", buf[1])
 		}
 	}
-	return nopad, localed, buf[len(buf)-1], nil
+	return nopad, localed, precision, buf[len(buf)-1], nil
 }
 
 func convert12To24HourClock(hour12 int, isAfternoon bool) (hour24 int) {

--- a/format_test.go
+++ b/format_test.go
@@ -10,13 +10,15 @@ import (
 )
 
 const (
-	formatYear  = 807
-	formatMonth = chrono.February
-	formatDay   = 9
-	formatHour  = 1
-	formatMin   = 5
-	formatSec   = 2
-	formatNsec  = 0
+	formatYear   = 807
+	formatMonth  = chrono.February
+	formatDay    = 9
+	formatHour   = 1
+	formatMin    = 5
+	formatSec    = 2
+	formatMillis = 123
+	formatMicros = 123457
+	formatNanos  = 123456789
 )
 
 func setupCenturyParsing() {
@@ -96,6 +98,24 @@ func checkSecond(t *testing.T, time chrono.LocalTime) {
 	}
 }
 
+func checkMillis(t *testing.T, time chrono.LocalTime) {
+	if nanos := time.Nanosecond(); nanos != formatMillis*1000000 {
+		t.Errorf("time.Nanosecond() = %d, want %d", nanos, formatMillis*1000000)
+	}
+}
+
+func checkMicros(t *testing.T, time chrono.LocalTime) {
+	if nanos := time.Nanosecond(); nanos != formatMicros*1000 {
+		t.Errorf("time.Nanosecond() = %d, want %d", nanos, formatMillis*1000)
+	}
+}
+
+func checkNanos(t *testing.T, time chrono.LocalTime) {
+	if nanos := time.Nanosecond(); nanos != formatNanos {
+		t.Errorf("time.Nanosecond() = %d, want %d", nanos, formatNanos)
+	}
+}
+
 var (
 	dateSpecifiers = []struct {
 		specifier         string
@@ -148,6 +168,10 @@ var (
 		{"%-M", "5", checkMinute},
 		{"%S", "02", checkSecond},
 		{"%-S", "2", checkSecond},
+		{"%3f", "123", checkMillis},
+		{"%6f", "123457", checkMicros},
+		{"%9f", "123456789", checkNanos},
+		{"%f", "123457", checkMicros},
 	}
 )
 
@@ -276,14 +300,14 @@ func TestLocalTime_Format_supported_specifiers(t *testing.T) {
 					}
 				}()
 
-				chrono.LocalTimeOf(formatHour, formatMin, formatSec, formatNsec).Format(tt.specifier)
+				chrono.LocalTimeOf(formatHour, formatMin, formatSec, formatNanos).Format(tt.specifier)
 			}()
 		})
 	}
 
 	for _, tt := range timeSpecifiers {
 		t.Run(tt.specifier, func(t *testing.T) {
-			if formatted := chrono.LocalTimeOf(formatHour, formatMin, formatSec, formatNsec).Format(tt.specifier); formatted != tt.text {
+			if formatted := chrono.LocalTimeOf(formatHour, formatMin, formatSec, formatNanos).Format(tt.specifier); formatted != tt.text {
 				t.Errorf("time.Format(%s) = %s, want %q", tt.specifier, formatted, tt.text)
 			}
 		})
@@ -293,7 +317,8 @@ func TestLocalTime_Format_supported_specifiers(t *testing.T) {
 func TestLocalDateTime_Format_supported_specifiers(t *testing.T) {
 	for _, tt := range dateSpecifiers {
 		t.Run(fmt.Sprintf("%s (%q)", tt.specifier, tt.textToParse), func(t *testing.T) {
-			if formatted := chrono.LocalDateTimeOf(formatYear, formatMonth, formatDay, formatHour, formatMin, formatSec, formatNsec).Format(tt.specifier); formatted != tt.expectedFormatted {
+			if formatted := chrono.LocalDateTimeOf(formatYear, formatMonth, formatDay, formatHour, formatMin, formatSec, formatNanos).
+				Format(tt.specifier); formatted != tt.expectedFormatted {
 				t.Errorf("datetime.Format(%s) = %s, want %q", tt.specifier, formatted, tt.expectedFormatted)
 			}
 		})
@@ -301,7 +326,8 @@ func TestLocalDateTime_Format_supported_specifiers(t *testing.T) {
 
 	for _, tt := range timeSpecifiers {
 		t.Run(tt.specifier, func(t *testing.T) {
-			if formatted := chrono.LocalDateTimeOf(formatYear, formatMonth, formatDay, formatHour, formatMin, formatSec, formatNsec).Format(tt.specifier); formatted != tt.text {
+			if formatted := chrono.LocalDateTimeOf(formatYear, formatMonth, formatDay, formatHour, formatMin, formatSec, formatNanos).
+				Format(tt.specifier); formatted != tt.text {
 				t.Errorf("datetime.Format(%s) = %s, want %q", tt.specifier, formatted, tt.text)
 			}
 		})

--- a/utils.go
+++ b/utils.go
@@ -25,3 +25,12 @@ func addInt64(v1, v2 int64) (sum int64, underflows, overflows bool) {
 	}
 	return v1 + v2, false, false
 }
+
+// divideAndRoundInt divides x by y, then rounds the result to the nearest multiple of y, either up or down.
+func divideAndRoundInt(x, y int) int {
+	r := x % y
+	if r >= (y / 2) {
+		return (x - r + y) / y
+	}
+	return (x - r) / y
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,21 @@
+package chrono_test
+
+import (
+	"testing"
+
+	"github.com/go-chrono/chrono"
+)
+
+func TestDivideAndRoundInt(t *testing.T) {
+	t.Run("round up", func(t *testing.T) {
+		if rounded := chrono.DivideAndRoundIntFunc(123456, 1000); rounded != 123 {
+			t.Errorf("RoundInt() = %d, want %d", rounded, 123)
+		}
+	})
+
+	t.Run("round down", func(t *testing.T) {
+		if rounded := chrono.DivideAndRoundIntFunc(123456789, 1000); rounded != 123457 {
+			t.Errorf("RoundInt() = %d, want %d", rounded, 123457)
+		}
+	})
+}


### PR DESCRIPTION
Closes https://github.com/go-chrono/chrono/issues/57.